### PR TITLE
Confirm Appveyor result in old version.

### DIFF
--- a/rgf/test/test.py
+++ b/rgf/test/test.py
@@ -350,5 +350,6 @@ class TestRGFRegressor(unittest.TestCase):
         self.assertLess(mse, 6.0)
 
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Appveyor is failed on Python3.4.
This PR is to confirm that failure is not caused by pickle support.