### PR TITLE
[fast-rgf] run examples as test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,7 @@ install:
   - cd ../..
 
 test_script:
-  - pytest tests/ examples/ -o "python_files=*.py" -v
+  - pytest tests/ -o "python_files=*.py" -v
   - pip uninstall -y rgf_python
   - python setup.py install
-  - pytest tests/ examples/ -o "python_files=*.py" -v
+  - pytest tests/ -o "python_files=*.py" -v

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn pytest
   - activate test-environment
   - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatebility will be fixed.
   - ps: $env:RGF_VER = (Get-Content rgf\VERSION).trim()
@@ -44,7 +44,7 @@ install:
   - cd ../..
 
 test_script:
-  - python tests/test.py
+  - pytest tests/ examples/ -o "python_files=*.py" -v
   - pip uninstall -y rgf_python
   - python setup.py install
-  - python tests/test.py
+  - pytest tests/ examples/ -o "python_files=*.py" -v

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,9 +26,10 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn pytest
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn
   - activate test-environment
   - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatebility will be fixed.
+  - pip install pytest>=3.3
   - ps: $env:RGF_VER = (Get-Content rgf\VERSION).trim()
   - python setup.py sdist --formats gztar
   - pip install dist\rgf_python-%RGF_VER%.tar.gz -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - RGF_VER=$(head -n 1 rgf/VERSION)
 
 install:
-  - conda install -q numpy scipy nose pandas scikit-learn
+  - conda install -q numpy scipy nose pandas scikit-learn pytest
   - python setup.py sdist --formats gztar
   - pip install dist/rgf_python-$RGF_VER.tar.gz -v
 
@@ -52,7 +52,7 @@ install:
   - cd ../..
 
 script:
-  - python tests/test.py
+  - pytest tests/ examples/ -o "python_files=*.py" -v
   - pip uninstall -y rgf_python
   - python setup.py install
-  - python tests/test.py
+  - pytest tests/ examples/ -o "python_files=*.py" -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - cd ../..
 
 script:
-  - pytest tests/ examples/ -o "python_files=*.py" -v
+  - pytest tests/ -o "python_files=*.py" -v
   - pip uninstall -y rgf_python
   - python setup.py install
-  - pytest tests/ examples/ -o "python_files=*.py" -v
+  - pytest tests/ -o "python_files=*.py" -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_install:
   - RGF_VER=$(head -n 1 rgf/VERSION)
 
 install:
-  - conda install -q numpy scipy nose pandas scikit-learn pytest
+  - conda install -q numpy scipy nose pandas scikit-learn
+  - pip install pytest>=3.3
   - python setup.py sdist --formats gztar
   - pip install dist/rgf_python-$RGF_VER.tar.gz -v
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -588,7 +588,3 @@ class TestFastRGFRegressor(_TestRGFRegressorBase):
         y_pred = grid.best_estimator_.predict(self.X_test)
         mse = mean_squared_error(self.y_test, y_pred)
         self.assertLess(mse, 6.0)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+import fnmatch
+import os
+import unittest
+
+
+def find_files(directory, pattern='*.py'):
+    for root, _, files in os.walk(directory):
+        for filename in files:
+            if fnmatch.fnmatch(filename, pattern):
+                filename = os.path.abspath(os.path.join(root, filename))
+                yield filename
+
+
+class TestExamples(unittest.TestCase):
+    def test_examples(self):
+        for filename in find_files(os.path.join(os.path.dirname(__file__), os.path.pardir, 'examples')):
+            exec(open(filename).read(), globals())


### PR DESCRIPTION
This PR makes examples to be treated as tests with the aim to be sure we are offering users executable code.

I tried to run tests with maximum verbose and find following results: https://travis-ci.org/StrikerRUS/rgf_python/jobs/309601149#L6705-L6719 (L6705 - L6719 ). Don't you find them strange, i.e. RGF faster than FastRGF?