### PR TITLE
updated appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
     - PYTHON_VERSION: 3.4
-      MINICONDA: C:\Miniconda3
+      MINICONDA: C:\Miniconda34
     - PYTHON_VERSION: 3.5
       MINICONDA: C:\Miniconda35
     - PYTHON_VERSION: 3.6


### PR DESCRIPTION
Updated path to Miniconda with Python 3.4 on Appveyor.

Refer to https://github.com/appveyor/website/commit/ccbf2c87ad7a17f2979e3697cc787073543679ea.