### PR TITLE
removed second round tests run

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,9 +48,6 @@ install:
 
 test_script:
   - pytest tests/ -o "python_files=*.py" -v
-  - pip uninstall -y rgf_python
-  - python setup.py install
-  - pytest tests/ -o "python_files=*.py" -v
 
 after_test:
   - IF "%PLATFORM%"=="x64" (

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,6 @@ install:
 
 script:
   - pytest tests/ -o "python_files=*.py" -v
-  - pip uninstall -y rgf_python
-  - python setup.py install
-  - pytest tests/ -o "python_files=*.py" -v
 
 before_deploy:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
@@ -90,4 +87,3 @@ deploy:
     condition: "$PYTHON_VERSION = 3.6"
 
     tags: true
-


### PR DESCRIPTION
I thinks that we could remove the second tests run iteration, because it takes too long to run tests. It's enough to run only `pip install ...` because anyway internally no wheels are used and `setup.py install` is launched.