### PR TITLE
fixed params

### DIFF
--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -26,62 +26,78 @@ class FastRGFRegressor(utils.RGFRegressorBase):
     ----------
     n_estimators : int, optional (default=500)
         The number of trees in the forest.
+        (Original name: forest.ntrees.)
 
     max_depth : int, optional (default=6)
         Maximum tree depth.
+        (Original name: dtree.max_level.)
 
     max_leaf : int, optional (default=50)
         Maximum number of leaf nodes in best-first search.
+        (Original name: dtree.max_nodes.)
 
     tree_gain_ratio : float, optional (default=1.0)
         New tree is created when leaf-nodes gain < this value * estimated gain
         of creating new tree.
+        (Original name: dtree.new_tree_gain_ratio.)
 
     min_samples_leaf : int or float, optional (default=5)
         Minimum number of training data points in each leaf node.
         If int, then consider min_samples_leaf as the minimum number.
         If float, then min_samples_leaf is a percentage and
         ceil(min_samples_leaf * n_samples) are the minimum number of samples for each node.
+        (Original name: dtree.min_sample.)
 
     l1 : float, optional (default=1.0)
         Used to control the degree of L1 regularization.
+        (Original name: dtree.lamL1.)
 
     l2 : float, optional (default=1000.0)
         Used to control the degree of L2 regularization.
+        (Original name: dtree.lamL2.)
 
     opt_algorithm : string ("rgf" or "epsilon-greedy"), optional (default="rgf")
         Optimization method for training forest.
+        (Original name: forest.opt.)
 
     learning_rate : float, optional (default=0.001)
         Step size of epsilon-greedy boosting.
         Meant for being used with opt_algorithm="epsilon-greedy".
+        (Original name: forest.stepsize.)
 
     max_bin : int or None, optional (default=None)
         Maximum number of discretized values (bins).
         If None, 65000 is used for dense data and 200 for sparse data.
+        (Original name: discretize.(sparse/dense).max_buckets.)
 
     min_child_weight : float, optional (default=5.0)
         Minimum sum of data weights for each discretized value (bin).
+        (Original name: discretize.(sparse/dense).min_bucket_weights.)
 
     data_l2 : float, optional (default=2.0)
         Used to control the degree of L2 regularization for discretization.
+        (Original name: discretize.(sparse/dense).lamL2.)
 
     sparse_max_features : int, optional (default=80000)
         Maximum number of selected features.
         Meant for being used with sparse data.
+        (Original name: discretize.sparse.max_features.)
 
     sparse_min_occurences : int, optional (default=5)
         Minimum number of occurrences for a feature to be selected.
         Meant for being used with sparse data.
+        (Original name: discretize.sparse.min_occrrences.)
 
     n_jobs : integer, optional (default=-1)
         The number of jobs to run in parallel for both fit and predict.
         If -1, all CPUs are used.
         If -2, all CPUs but one are used.
         If < -1, (n_cpus + 1 + n_jobs) are used.
+        (Original name: set.nthreads.)
 
     verbose : int, optional (default=0)
         Controls the verbosity of the tree building process.
+        (Original name: set.verbose.)
 
     Attributes:
     -----------
@@ -268,59 +284,74 @@ class FastRGFClassifier(utils.RGFClassifierBase):
     ----------
     n_estimators : int, optional (default=500)
         The number of trees in the forest.
+        (Original name: forest.ntrees.)
 
     max_depth : int, optional (default=6)
         Maximum tree depth.
+        (Original name: dtree.max_level.)
 
     max_leaf : int, optional (default=50)
         Maximum number of leaf nodes in best-first search.
+        (Original name: dtree.max_nodes.)
 
     tree_gain_ratio : float, optional (default=1.0)
         New tree is created when leaf-nodes gain < this value * estimated gain
         of creating new tree.
+        (Original name: dtree.new_tree_gain_ratio.)
 
     min_samples_leaf : int or float, optional (default=5)
         Minimum number of training data points in each leaf node.
         If int, then consider min_samples_leaf as the minimum number.
         If float, then min_samples_leaf is a percentage and
         ceil(min_samples_leaf * n_samples) are the minimum number of samples for each node.
+        (Original name: dtree.min_sample.)
 
     loss : string ("LS" or "MODLS" or "LOGISTIC"), optional (default="LS")
         Loss function.
         LS: Least squares loss.
         MODLS: Modified least squares loss.
         LOGISTIC: Logistic loss.
+        (Original name: dtree.loss.)
 
     l1 : float, optional (default=1.0)
         Used to control the degree of L1 regularization.
+        (Original name: dtree.lamL1.)
 
     l2 : float, optional (default=1000.0)
         Used to control the degree of L2 regularization.
+        (Original name: dtree.lamL2.)
 
     opt_algorithm : string ("rgf" or "epsilon-greedy"), optional (default="rgf")
         Optimization method for training forest.
+        (Original name: forest.opt.)
 
     learning_rate : float, optional (default=0.001)
         Step size of epsilon-greedy boosting.
         Meant for being used with opt_algorithm="epsilon-greedy".
+        (Original name: forest.stepsize.)
 
     max_bin : int or None, optional (default=None)
         Maximum number of discretized values (bins).
         If None, 65000 is used for dense data and 200 for sparse data.
+        (Original name: discretize.(sparse/dense).max_buckets.)
 
     min_child_weight : float, optional (default=5.0)
         Minimum sum of data weights for each discretized value (bin).
+        (Original name: discretize.(sparse/dense).min_bucket_weights.)
 
     data_l2 : float, optional (default=2.0)
         Used to control the degree of L2 regularization for discretization.
+        (Original name: discretize.(sparse/dense).lamL2.)
 
     sparse_max_features : int, optional (default=80000)
         Maximum number of selected features.
         Meant for being used with sparse data.
+        (Original name: discretize.sparse.max_features.)
 
     sparse_min_occurences : int, optional (default=5)
         Minimum number of occurrences for a feature to be selected.
         Meant for being used with sparse data.
+        (Original name: discretize.sparse.min_occrrences.)
 
     calc_prob : string ("sigmoid" or "softmax"), optional (default="sigmoid")
         Method of probability calculation.
@@ -330,9 +361,11 @@ class FastRGFClassifier(utils.RGFClassifierBase):
         If -1, all CPUs are used.
         If -2, all CPUs but one are used.
         If < -1, (n_cpus + 1 + n_jobs) are used.
+        (Original name: set.nthreads.)
 
     verbose : int, optional (default=0)
         Controls the verbosity of the tree building process.
+        (Original name: set.verbose.)
 
     Attributes:
     -----------

--- a/rgf/rgf_model.py
+++ b/rgf/rgf_model.py
@@ -308,7 +308,7 @@ class RGFRegressor(utils.RGFRegressorBase):
             self._sl2 = self.sl2
 
         if isinstance(self.min_samples_leaf, utils.FLOATS):
-            self._min_samples_leaf = ceil(self.min_samples_leaf * n_samples)
+            self._min_samples_leaf = ceil(self.min_samples_leaf * self._n_samples)
         else:
             self._min_samples_leaf = self.min_samples_leaf
 
@@ -595,7 +595,7 @@ class RGFClassifier(utils.RGFClassifierBase):
             self._sl2 = self.sl2
 
         if isinstance(self.min_samples_leaf, utils.FLOATS):
-            self._min_samples_leaf = ceil(self.min_samples_leaf * n_samples)
+            self._min_samples_leaf = ceil(self.min_samples_leaf * self._n_samples)
         else:
             self._min_samples_leaf = self.min_samples_leaf
 

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -243,12 +243,10 @@ class RGFRegressorBase(BaseEstimator, RegressorMixin):
         self._validate_params(self.get_params())
 
         X, y = check_X_y(X, y, accept_sparse=True, multi_output=False, y_numeric=True)
-        n_samples, self._n_features = X.shape
-
-        self._set_params_with_dependencies()
+        self._n_samples, self._n_features = X.shape
 
         if sample_weight is None:
-            sample_weight = np.ones(n_samples, dtype=np.float32)
+            sample_weight = np.ones(self._n_samples, dtype=np.float32)
         else:
             sample_weight = column_or_1d(sample_weight, warn=True)
             if (sample_weight <= 0).any():
@@ -270,6 +268,8 @@ class RGFRegressorBase(BaseEstimator, RegressorMixin):
         else:
             self._save_dense_files(X, y, sample_weight)
             self._is_sparse_train_X = False
+
+        self._set_params_with_dependencies()
 
         cmd = self._get_train_command()
 
@@ -452,12 +452,14 @@ class RGFClassifierBase(BaseEstimator, ClassifierMixin):
         self._validate_params(self.get_params())
 
         X, y = check_X_y(X, y, accept_sparse=True)
-        n_samples, self._n_features = X.shape
-
-        self._set_params_with_dependencies()
+        if sp.isspmatrix(X):
+            self._is_sparse_train_X = True
+        else:
+            self._is_sparse_train_X = False
+        self._n_samples, self._n_features = X.shape
 
         if sample_weight is None:
-            sample_weight = np.ones(n_samples, dtype=np.float32)
+            sample_weight = np.ones(self._n_samples, dtype=np.float32)
         else:
             sample_weight = column_or_1d(sample_weight, warn=True)
             if (sample_weight <= 0).any():
@@ -467,6 +469,8 @@ class RGFClassifierBase(BaseEstimator, ClassifierMixin):
 
         self._classes = sorted(np.unique(y))
         self._n_classes = len(self._classes)
+
+        self._set_params_with_dependencies()
 
         params = self._get_params()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -302,7 +302,7 @@ class TestFastRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
         # np.testing.assert_equal(y_pred_weighted, np.full(self.y_test.shape[0], self.y_test[0]))
 
     def test_parallel_gridsearch(self):
-        param_grid = dict(forest_ntrees=[100, 300])
+        param_grid = dict(n_estimators=[100, 300])
         grid = GridSearchCV(self.classifier_class(n_jobs=1),
                             param_grid=param_grid, refit=True, cv=2, verbose=0, n_jobs=-1)
         grid.fit(self.X_train, self.y_train)
@@ -554,7 +554,7 @@ class TestFastRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):
         pass
 
     def test_parallel_gridsearch(self):
-        param_grid = dict(forest_ntrees=[100, 500])
+        param_grid = dict(n_estimators=[100, 500])
         grid = GridSearchCV(self.regressor_class(n_jobs=1),
                             param_grid=param_grid, refit=True, cv=2, verbose=0, n_jobs=-1)
         grid.fit(self.X_train, self.y_train)


### PR DESCRIPTION
This PR makes params names shorter and more familiar for users.
Also there is no need to pass all params because there is no possibility to mix dense and sparse features in one `fit` launch.
`loss` param is actually only for classification task, regression task can only optimize least squares objective, so it has been removed from `FastRGFRegressor`.
Refer to #91.