### PR TITLE
Appveyor deployment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,19 +8,23 @@ platform:
 environment:
   matrix:
     - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
     - PYTHON_VERSION: 3.4
-      MINICONDA: C:\Miniconda34
     - PYTHON_VERSION: 3.5
-      MINICONDA: C:\Miniconda35
     - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda36
 
 clone_depth: 50
 
 install:
   - git submodule update --init --recursive  # retrieve fast_rgf
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # Delete sh.exe from PATH (mingw32-make fix)
+  - ps: >-
+      switch ($env:PYTHON_VERSION) {
+          "2.7" {$env:MINICONDA = """C:\Miniconda"""}
+          "3.4" {$env:MINICONDA = """C:\Miniconda34"""}
+          "3.5" {$env:MINICONDA = """C:\Miniconda35"""}
+          "3.6" {$env:MINICONDA = """C:\Miniconda36"""}
+          default {$env:MINICONDA = """C:\Miniconda36"""}
+      }
   - ps: if($env:PLATFORM -eq "x64") {
             $env:MINICONDA += "-x64";
             $env:PATH += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,4 +73,4 @@ deploy:
   on:
     appveyor_repo_tag: true
     branch: master
-    PYTHON_VERSION: 2.7
+    PYTHON_VERSION: 3.6

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,7 @@ test_script:
 after_test:
   - ps: >-
       if(
-         -not $env:APPVEYOR_REPO_TAG -or
+         $env:APPVEYOR_REPO_TAG -eq "false" -or
          $env:PYTHON_VERSION -ne "2.7") {
           Exit-AppVeyorBuild
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   provider: GitHub
   auth_token:
-    secure: cd394d509c9d8f19e020dd2ebc21e3b7ba3bf731
+    secure: iGMgQcGFl96QWnliaddwr6xESvFviRt5J9pmLlJvyLP1OZYgeFr5Jutgq7UE0THX
   artifact: pip
   force_update: true
   draft: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,9 +47,9 @@ test_script:
 
 after_test:
   - ps: >-
-      if(!($env:APPVEYOR_REPO_TAG)
-         -Or !($env:APPVEYOR_REPO_BRANCH -eq "master")
-         -Or !($env:PYTHON_VERSION -eq "2.7")) {
+      if(-not $env:APPVEYOR_REPO_TAG
+         -or $env:APPVEYOR_REPO_BRANCH -ne "master"
+         -or $env:PYTHON_VERSION -ne "2.7") {
           Exit-AppVeyorBuild
       }
   - IF "%PLATFORM%"=="x64" (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,3 +49,16 @@ before_deploy:
 artifacts:
   - path: dist/*
     name: pip
+
+
+deploy:
+  release: $(APPVEYOR_REPO_TAG_NAME)
+  provider: GitHub
+  auth_token:
+    secure: 
+  artifact: pip
+  force_update: true
+  draft: true
+  on:
+#    branch: master
+    appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,6 @@ after_test:
   - ps: >-
       if(
          -not $env:APPVEYOR_REPO_TAG -or
-         $env:APPVEYOR_REPO_BRANCH -ne "master" -or
          $env:PYTHON_VERSION -ne "2.7") {
           Exit-AppVeyorBuild
       }
@@ -74,3 +73,5 @@ deploy:
     appveyor_repo_tag: true
 #    branch: master
     PYTHON_VERSION: 2.7
+
+#          $env:APPVEYOR_REPO_BRANCH -ne "master" -or

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,20 +36,21 @@ install:
   - conda update -q conda
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn
   - activate test-environment
-#  - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatibility will be fixed.
-#  - pip install "pytest>=3.3"
+  - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatibility will be fixed.
+  - pip install "pytest>=3.3"
   - ps: $env:RGF_VER = (Get-Content rgf\VERSION).trim()
-#  - python setup.py sdist --formats gztar
-#  - pip install dist\rgf_python-%RGF_VER%.tar.gz -v
+  - python setup.py sdist --formats gztar
+  - pip install dist\rgf_python-%RGF_VER%.tar.gz -v
 
 test_script:
-#  - pytest tests/ -o "python_files=*.py" -v
+  - pytest tests/ -o "python_files=*.py" -v
 
 after_test:
   - ps: >-
       if(
          $env:APPVEYOR_REPO_TAG -eq "false" -or
-         $env:PYTHON_VERSION -ne "2.7") {
+         $env:APPVEYOR_REPO_BRANCH -ne "master" -or
+         $env:PYTHON_VERSION -ne "3.6") {
           Exit-AppVeyorBuild
       }
   - IF "%PLATFORM%"=="x64" (
@@ -65,13 +66,11 @@ deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   provider: GitHub
   auth_token:
-    secure: RuZmlRFD5gcBCSniGrRqKZNzaUkcTuRkdWYrOSXm5NyEL/WCZoa/mYKC+p49k2E2
+    secure: your encrypted GitHub Personal Access Token here
   artifact: pip
   force_update: true
   draft: true
   on:
     appveyor_repo_tag: true
-#    branch: master
+    branch: master
     PYTHON_VERSION: 2.7
-
-#          $env:APPVEYOR_REPO_BRANCH -ne "master" -or

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ deploy:
   auth_token:
     secure: RuZmlRFD5gcBCSniGrRqKZNzaUkcTuRkdWYrOSXm5NyEL/WCZoa/mYKC+p49k2E2
   artifact: pip
-#  force_update: true
+  force_update: true
   draft: true
   on:
     appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ install:
 test_script:
   - pytest tests/ -o "python_files=*.py" -v
 
-after_test:
+before_deploy:
   - IF "%PLATFORM%"=="x64" (
     python setup.py bdist_wheel --plat-name=win-amd64 --universal)
     ELSE (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   provider: GitHub
   auth_token:
-    secure: your encrypted GitHub Personal Access Token here
+    secure: cd394d509c9d8f19e020dd2ebc21e3b7ba3bf731
   artifact: pip
   force_update: true
   draft: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,18 +18,19 @@ install:
   - git submodule update --init --recursive  # retrieve fast_rgf
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%  # Delete sh.exe from PATH (mingw32-make fix)
   - ps: >-
-      switch ($env:PYTHON_VERSION) {
+      switch($env:PYTHON_VERSION) {
           "2.7" {$env:MINICONDA = """C:\Miniconda"""}
           "3.4" {$env:MINICONDA = """C:\Miniconda34"""}
           "3.5" {$env:MINICONDA = """C:\Miniconda35"""}
           "3.6" {$env:MINICONDA = """C:\Miniconda36"""}
           default {$env:MINICONDA = """C:\Miniconda36"""}
       }
-  - ps: if($env:PLATFORM -eq "x64") {
-            $env:MINICONDA += "-x64";
-            $env:PATH += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
-        }
-        else {$env:PATH += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"}
+  - ps: >-
+      if($env:PLATFORM -eq "x64") {
+          $env:MINICONDA += "-x64";
+          $env:PATH += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
+      }
+      else {$env:PATH += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"}
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
@@ -44,7 +45,13 @@ install:
 test_script:
   - pytest tests/ -o "python_files=*.py" -v
 
-before_deploy:
+after_test:
+  - ps: >-
+      if(!($env:APPVEYOR_REPO_TAG)
+         -Or !($env:APPVEYOR_REPO_BRANCH -eq "master")
+         -Or !($env:PYTHON_VERSION -eq "2.7")) {
+          Exit-AppVeyorBuild
+      }
   - IF "%PLATFORM%"=="x64" (
     python setup.py bdist_wheel --plat-name=win-amd64 --universal)
     ELSE (
@@ -54,15 +61,15 @@ artifacts:
   - path: dist/*
     name: pip
 
-
 deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   provider: GitHub
   auth_token:
-    secure: 
+    secure: RuZmlRFD5gcBCSniGrRqKZNzaUkcTuRkdWYrOSXm5NyEL/WCZoa/mYKC+p49k2E2
   artifact: pip
-  force_update: true
+#  force_update: true
   draft: true
   on:
-#    branch: master
     appveyor_repo_tag: true
+#    branch: master
+    PYTHON_VERSION: 2.7

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,9 +47,10 @@ test_script:
 
 after_test:
   - ps: >-
-      if(-not $env:APPVEYOR_REPO_TAG
-         -or $env:APPVEYOR_REPO_BRANCH -ne "master"
-         -or $env:PYTHON_VERSION -ne "2.7") {
+      if(
+         -not $env:APPVEYOR_REPO_TAG -or
+         $env:APPVEYOR_REPO_BRANCH -ne "master" -or
+         $env:PYTHON_VERSION -ne "2.7") {
           Exit-AppVeyorBuild
       }
   - IF "%PLATFORM%"=="x64" (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,14 +36,14 @@ install:
   - conda update -q conda
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose pandas scikit-learn
   - activate test-environment
-  - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatibility will be fixed.
-  - pip install "pytest>=3.3"
+#  - conda install mkl=2017.0.3  # Temp fix. Delete the line in the future when compatibility will be fixed.
+#  - pip install "pytest>=3.3"
   - ps: $env:RGF_VER = (Get-Content rgf\VERSION).trim()
-  - python setup.py sdist --formats gztar
-  - pip install dist\rgf_python-%RGF_VER%.tar.gz -v
+#  - python setup.py sdist --formats gztar
+#  - pip install dist\rgf_python-%RGF_VER%.tar.gz -v
 
 test_script:
-  - pytest tests/ -o "python_files=*.py" -v
+#  - pytest tests/ -o "python_files=*.py" -v
 
 after_test:
   - ps: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,8 @@ deploy:
   provider: releases
   api-key:
     secure: "WGMJ/0VoQ34g1m9k6RkxLOS796HRgK0M8JsVUSs2zW3miwmGGRvh5p8cn+IlOJD0uJyZQksueyN5aEVwUZ5tDuNHb21CDUDupxNjt74EqWAB1fc9Dp72sSWImIPY6PEA/f8OTwQKI00B9WfDJJMPOdlPN57gq7+DlJLsEtWxXssvs/l5JiBc4qO1CwA+y4460cpTrBgB3VnhAF6tju6H4dJtj8lWtXdnFc9gUF/3xTi1QliGrE4doQyLoNOAr4pzNgNjeUjkw9yVKUfa2XsQhyCcLZjBg4Z1t4P15nN/NRaQv/IaYu2WjbRIW1bVadfHUVmuf5F2oRLmR2KrWaJSYTd7wsr+6/Pd/ejZXoL5XJCjCFRxJKHbdL4zIUJa50Auqw6NAwoZSqrLatfsxEjXZaUhaGPg63f44GOA8RSB4X3txPwTXPwXCb8QSq51rfm2zPe6UEvfiVGlyylHtTwP+GKqy1Ml4q+0HPCjne1qufLtNhy+Ke6rD7KgODJi/XElmJwhF8pPCeDp+AmMYbd+Ppid0sISJFCv4IJmAl3FUJ5dtH/wGFUWMQDH8zsF1v94AFXmuO0zvaoOnKOC7P+j3/UXqOUopdC4z0YYqkjJU+OkWO/rnhHhFoWQjys3f1D1q/++yF7wwEu/DkUbxr/29YV2hfa5yH/gHusLmX01d1o="
-
   tag_name: $TRAVIS_TAG
   on:
     branch: master
     condition: "$PYTHON_VERSION = 3.6"
-
     tags: true


### PR DESCRIPTION
This PR reduces test time(#122) by building artifacts only in Python 3.6 build and only in case of tagged commit to the master branch. Also now artifacts deployed to GitHub (draft) Releases (like Travis).