### PR TITLE
updated FastRGF submodule

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -298,10 +298,6 @@ Known Issues
 
 * FastRGF crashes if training dataset is too small (#data < 28). (`rgf\_python#92 <https://github.com/fukatani/rgf_python/issues/92>`__)
 
-* FastRGF crashes if sample weights is too small. The value of the weight is dependent on the size of the dataset. (`rgf\_python#137 <https://github.com/fukatani/rgf_python/issues/137>`__)
-
-  For instance, ``sample_weight = [0.001, 0.001, ..., 0.001]`` leads to a crash for #data < 200.
-
 * **rgf\_python** does not provide any built-in method to calculate feature importances. (`rgf\_python#109 <https://github.com/fukatani/rgf_python/issues/109>`__)
 
 FAQ

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -181,7 +181,7 @@ class FastRGFRegressor(utils.RGFRegressorBase):
         (Original name: discretize.(sparse/dense).max_buckets.)
 
     min_child_weight : float, optional (default=5.0)
-        Minimum sum of data weights for each discretized value (bin).
+        Minimum number of effective samples for each discretized value (bin).
         (Original name: discretize.(sparse/dense).min_bucket_weights.)
 
     data_l2 : float, optional (default=2.0)
@@ -447,7 +447,7 @@ class FastRGFClassifier(utils.RGFClassifierBase):
         (Original name: discretize.(sparse/dense).max_buckets.)
 
     min_child_weight : float, optional (default=5.0)
-        Minimum sum of data weights for each discretized value (bin).
+        Minimum number of effective samples for each discretized value (bin).
         (Original name: discretize.(sparse/dense).min_bucket_weights.)
 
     data_l2 : float, optional (default=2.0)

--- a/tests/test_rgf_python.py
+++ b/tests/test_rgf_python.py
@@ -352,21 +352,6 @@ class TestFastRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
         else:
             self.assertEqual(clf.min_samples_leaf_, clf.min_samples_leaf)
 
-    def test_sample_weight(self):
-        clf = self.classifier_class(**self.kwargs)
-        y_pred = clf.fit(self.X_train, self.y_train).predict_proba(self.X_test)
-        y_pred_weighted = clf.fit(self.X_train,
-                                  self.y_train,
-                                  np.ones(self.y_train.shape[0])
-                                  ).predict_proba(self.X_test)
-        np.testing.assert_allclose(y_pred, y_pred_weighted)
-        # TODO(fukatani): FastRGF bug?
-        # does not work if weight is too small
-        # weights = np.ones(self.y_train.shape[0]) * 0.01
-        # weights[0] = 100
-        # y_pred_weighted = clf.fit(self.X_train, self.y_train, weights).predict(self.X_test)
-        # np.testing.assert_equal(y_pred_weighted, np.full(self.y_test.shape[0], self.y_test[0]))
-
     def test_sklearn_integration(self):
         # TODO(fukatani): FastRGF bug?
         # FastRGF doesn't work if the number of sample is too small.
@@ -642,28 +627,6 @@ class TestFastRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):
     def test_parallel_gridsearch(self):
         self.kwargs['n_jobs'] = 1
         super(TestFastRGFRegressor, self).test_parallel_gridsearch()
-
-    def test_sample_weight(self):
-        reg = self.regressor_class(**self.kwargs)
-
-        y_pred = reg.fit(self.X_train, self.y_train).predict(self.X_test)
-        y_pred_weighted = reg.fit(self.X_train,
-                                  self.y_train,
-                                  np.ones(self.y_train.shape[0])
-                                  ).predict(self.X_test)
-        np.testing.assert_allclose(y_pred, y_pred_weighted)
-        # TODO(fukatani): FastRGF bug?
-        # does not work if weight is too small
-        # np.random.seed(42)
-        # idx = np.random.choice(400, 80, replace=False)
-        # self.X_train[idx] = -99999  # Add some outliers
-        # y_pred_corrupt = reg.fit(self.X_train, self.y_train).predict(self.X_test)
-        # mse_corrupt = mean_squared_error(self.y_test, y_pred_corrupt)
-        # weights = np.ones(self.y_train.shape[0]) * 100
-        # weights[idx] = 1  # Eliminate outliers
-        # y_pred_weighted = reg.fit(self.X_train, self.y_train, weights).predict(self.X_test)
-        # mse_fixed = mean_squared_error(self.y_test, y_pred_weighted)
-        # self.assertLess(mse_fixed, mse_corrupt)
 
     def test_sklearn_integration(self):
         # TODO(fukatani): FastRGF bug?


### PR DESCRIPTION
Fixed #137. Now FastRGF can deal with small weights.

Unfortunately last changes in FastRGF repo led to huge score degradation and now FastRGF cannot deal with Friedman1 problem (returns all zeros, so in consequence MSE increases from ~2 to 211).