### PR TITLE
refactored sample_weight

### DIFF
--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -340,12 +340,17 @@ class FastRGFRegressor(utils.RGFRegressorBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            params.append("trn.w-file=%s" % self._train_weight_loc)
+            if self.save_weights:
+                params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self._max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            params.append("trn.x-file_format=w.y.x")
+            if self.save_weights:
+                fmt = "w.y.x"
+            else:
+                fmt = "y.x"
+            params.append("trn.x-file_format=%s" % fmt)
         params.append("trn.x-file=%s" % self._train_x_loc)
         params.append("trn.target=REAL")
         params.append("set.nthreads=%s" % self._n_jobs)
@@ -378,7 +383,9 @@ class FastRGFRegressor(utils.RGFRegressorBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        np.savetxt(self._train_x_loc, np.c_[sample_weight, y, X], delimiter=' ', fmt="%s")
+        np.savetxt(self._train_x_loc,
+                   np.c_[arr for arr in (sample_weight, y, X) if arr is not None],
+                   delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
         if not os.path.isfile(self._model_file_loc):
@@ -642,7 +649,9 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        np.savetxt(self._train_x_loc, np.c_[sample_weight, y, X], delimiter=' ', fmt="%s")
+        np.savetxt(self._train_x_loc,
+                   np.c_[arr for arr in (sample_weight, y, X) if arr is not None],
+                   delimiter=' ', fmt="%s")
 
     def _get_train_command(self):
         params = []
@@ -664,12 +673,17 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            params.append("trn.w-file=%s" % self._train_weight_loc)
+            if self.save_weights:
+                params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self.max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            params.append("trn.x-file_format=w.y.x")
+            if self.save_weights:
+                fmt = "w.y.x"
+            else:
+                fmt = "y.x"
+            params.append("trn.x-file_format=%s" % fmt)
         params.append("trn.x-file=%s" % self._train_x_loc)
         params.append("trn.target=BINARY")
         params.append("set.nthreads=%s" % self.n_jobs)

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -383,7 +383,7 @@ class FastRGFRegressor(utils.RGFRegressorBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        if sample_weight is not None:
+        if self._save_weights:
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)
@@ -653,7 +653,7 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        if sample_weight is not None:
+        if self._save_weights:
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -383,8 +383,12 @@ class FastRGFRegressor(utils.RGFRegressorBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
+        if sample_weight is not None:
+            arrs = (sample_weight, y, X)
+        else:
+            arrs = (y, X)
         np.savetxt(self._train_x_loc,
-                   np.c_[arr for arr in (sample_weight, y, X) if arr is not None],
+                   np.c_[arrs],
                    delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
@@ -649,8 +653,12 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
+        if sample_weight is not None:
+            arrs = (sample_weight, y, X)
+        else:
+            arrs = (y, X)
         np.savetxt(self._train_x_loc,
-                   np.c_[arr for arr in (sample_weight, y, X) if arr is not None],
+                   np.c_[arrs],
                    delimiter=' ', fmt="%s")
 
     def _get_train_command(self):

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -340,13 +340,13 @@ class FastRGFRegressor(utils.RGFRegressorBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            if self.save_weights:
+            if self._save_weights:
                 params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self._max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            if self.save_weights:
+            if self._save_weights:
                 fmt = "w.y.x"
             else:
                 fmt = "y.x"
@@ -681,13 +681,13 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            if self.save_weights:
+            if self._save_weights:
                 params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self.max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            if self.save_weights:
+            if self._save_weights:
                 fmt = "w.y.x"
             else:
                 fmt = "y.x"

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -387,9 +387,7 @@ class FastRGFRegressor(utils.RGFRegressorBase):
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)
-        np.savetxt(self._train_x_loc,
-                   np.c_[arrs],
-                   delimiter=' ', fmt="%s")
+        np.savetxt(self._train_x_loc, np.c_[arrs], delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
         if not os.path.isfile(self._model_file_loc):
@@ -657,9 +655,7 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)
-        np.savetxt(self._train_x_loc,
-                   np.c_[arrs],
-                   delimiter=' ', fmt="%s")
+        np.savetxt(self._train_x_loc, np.c_[arrs], delimiter=' ', fmt="%s")
 
     def _get_train_command(self):
         params = []

--- a/rgf/fastrgf_model.py
+++ b/rgf/fastrgf_model.py
@@ -340,13 +340,13 @@ class FastRGFRegressor(utils.RGFRegressorBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            if self._save_weights:
+            if self._use_sample_weight:
                 params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self._max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            if self._save_weights:
+            if self._use_sample_weight:
                 fmt = "w.y.x"
             else:
                 fmt = "y.x"
@@ -383,7 +383,7 @@ class FastRGFRegressor(utils.RGFRegressorBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        if self._save_weights:
+        if self._use_sample_weight:
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)
@@ -651,7 +651,7 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
 
     def _save_dense_files(self, X, y, sample_weight):
         self._train_x_loc = self._train_x_loc[:-2]
-        if self._save_weights:
+        if self._use_sample_weight:
             arrs = (sample_weight, y, X)
         else:
             arrs = (y, X)
@@ -677,13 +677,13 @@ class FastRGFBinaryClassifier(utils.RGFBinaryClassifierBase):
             params.append("discretize.sparse.min_occrrences=%s" % self.sparse_min_occurences)
             params.append("trn.x-file_format=x.sparse")
             params.append("trn.y-file=%s" % self._train_y_loc)
-            if self._save_weights:
+            if self._use_sample_weight:
                 params.append("trn.w-file=%s" % self._train_weight_loc)
         else:
             params.append("discretize.dense.max_buckets=%s" % self.max_bin)
             params.append("discretize.dense.lamL2=%s" % self.data_l2)
             params.append("discretize.dense.min_bucket_weights=%s" % self.min_child_weight)
-            if self._save_weights:
+            if self._use_sample_weight:
                 fmt = "w.y.x"
             else:
                 fmt = "y.x"

--- a/rgf/rgf_model.py
+++ b/rgf/rgf_model.py
@@ -346,7 +346,7 @@ class RGFRegressor(utils.RGFRegressorBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        if self.save_weights:
+        if self._save_weights:
             params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))
@@ -369,7 +369,7 @@ class RGFRegressor(utils.RGFRegressorBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        if self.save_weights:
+        if self._save_weights:
             np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
@@ -665,7 +665,7 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        if self.save_weights:
+        if self._save_weights:
             np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _get_train_command(self):
@@ -692,7 +692,7 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        if self.save_weights:
+        if self._save_weights:
             params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))

--- a/rgf/rgf_model.py
+++ b/rgf/rgf_model.py
@@ -346,7 +346,8 @@ class RGFRegressor(utils.RGFRegressorBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        params.append("train_w_fn=%s" % self._train_weight_loc)
+        if self.save_weights:
+            params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))
 
@@ -368,7 +369,8 @@ class RGFRegressor(utils.RGFRegressorBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
+        if self.save_weights:
+            np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
         # Find latest model location
@@ -663,7 +665,8 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
+        if self.save_weights:
+            np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _get_train_command(self):
         params = []
@@ -689,7 +692,8 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        params.append("train_w_fn=%s" % self._train_weight_loc)
+        if self.save_weights:
+            params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))
 

--- a/rgf/rgf_model.py
+++ b/rgf/rgf_model.py
@@ -346,7 +346,7 @@ class RGFRegressor(utils.RGFRegressorBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        if self._save_weights:
+        if self._use_sample_weight:
             params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))
@@ -369,7 +369,7 @@ class RGFRegressor(utils.RGFRegressorBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        if self._save_weights:
+        if self._use_sample_weight:
             np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _find_model_file(self):
@@ -665,7 +665,7 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
     def _save_dense_files(self, X, y, sample_weight):
         np.savetxt(self._train_x_loc, X, delimiter=' ', fmt="%s")
         np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-        if self._save_weights:
+        if self._use_sample_weight:
             np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
 
     def _get_train_command(self):
@@ -692,7 +692,7 @@ class RGFBinaryClassifier(utils.RGFBinaryClassifierBase):
         params.append("opt_stepsize=%s" % self.learning_rate)
         params.append("memory_policy=%s" % self.memory_policy.title())
         params.append("model_fn_prefix=%s" % self._model_file_loc)
-        if self._save_weights:
+        if self._use_sample_weight:
             params.append("train_w_fn=%s" % self._train_weight_loc)
 
         cmd = (utils.RGF_PATH, "train", ",".join(params))

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -263,10 +263,8 @@ class RGFMixin(object):
             return self._fitted
 
     def _get_sample_weight(self, sample_weight):
-        self._save_weights = False
         if sample_weight is not None:
             sample_weight = column_or_1d(sample_weight, warn=True)
-            self._save_weights = True
             if (sample_weight <= 0).any():
                 raise ValueError("Sample weights must be positive.")
         return sample_weight
@@ -280,6 +278,11 @@ class RGFMixin(object):
         self._pred_loc = os.path.join(TEMP_PATH, self._file_prefix + ".predictions.txt")
 
     def _save_train_data(self, X, y, sample_weight):
+        if sample_weight is None:
+            self._save_weights = False
+        else:
+            self._save_weights = True
+
         if sp.isspmatrix(X):
             self._save_sparse_X(self._train_x_loc, X)
             np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -279,14 +279,14 @@ class RGFMixin(object):
 
     def _save_train_data(self, X, y, sample_weight):
         if sample_weight is None:
-            self._save_weights = False
+            self._use_sample_weight = False
         else:
-            self._save_weights = True
+            self._use_sample_weight = True
 
         if sp.isspmatrix(X):
             self._save_sparse_X(self._train_x_loc, X)
             np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-            if self._save_weights:
+            if self._use_sample_weight:
                 np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
             self._is_sparse_train_X = True
         else:

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -263,8 +263,10 @@ class RGFMixin(object):
             return self._fitted
 
     def _get_sample_weight(self, sample_weight):
+        self._save_weights = False
         if sample_weight is not None:
             sample_weight = column_or_1d(sample_weight, warn=True)
+            self._save_weights = True
             if (sample_weight <= 0).any():
                 raise ValueError("Sample weights must be positive.")
         return sample_weight
@@ -278,10 +280,6 @@ class RGFMixin(object):
         self._pred_loc = os.path.join(TEMP_PATH, self._file_prefix + ".predictions.txt")
 
     def _save_train_data(self, X, y, sample_weight):
-        if sample_weight is None:
-            self._save_weights = False
-        else:
-            self._save_weights = True
         if sp.isspmatrix(X):
             self._save_sparse_X(self._train_x_loc, X)
             np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -279,13 +279,13 @@ class RGFMixin(object):
 
     def _save_train_data(self, X, y, sample_weight):
         if sample_weight is None:
-            self.save_weights = False
+            self._save_weights = False
         else:
-            self.save_weights = True
+            self._save_weights = True
         if sp.isspmatrix(X):
             self._save_sparse_X(self._train_x_loc, X)
             np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-            if self.save_weights:
+            if self._save_weights:
                 np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
             self._is_sparse_train_X = True
         else:

--- a/rgf/utils.py
+++ b/rgf/utils.py
@@ -263,9 +263,7 @@ class RGFMixin(object):
             return self._fitted
 
     def _get_sample_weight(self, sample_weight):
-        if sample_weight is None:
-            sample_weight = np.ones(self._n_samples, dtype=np.float32)
-        else:
+        if sample_weight is not None:
             sample_weight = column_or_1d(sample_weight, warn=True)
             if (sample_weight <= 0).any():
                 raise ValueError("Sample weights must be positive.")
@@ -280,10 +278,15 @@ class RGFMixin(object):
         self._pred_loc = os.path.join(TEMP_PATH, self._file_prefix + ".predictions.txt")
 
     def _save_train_data(self, X, y, sample_weight):
+        if sample_weight is None:
+            self.save_weights = False
+        else:
+            self.save_weights = True
         if sp.isspmatrix(X):
             self._save_sparse_X(self._train_x_loc, X)
             np.savetxt(self._train_y_loc, y, delimiter=' ', fmt="%s")
-            np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
+            if self.save_weights:
+                np.savetxt(self._train_weight_loc, sample_weight, delimiter=' ', fmt="%s")
             self._is_sparse_train_X = True
         else:
             self._save_dense_files(X, y, sample_weight)


### PR DESCRIPTION
Now real `sample_weight` is `None` if it was specified as `None` (was `np.ones()`).

It should save disk space and (maybe) make training faster if C++ code allows it.